### PR TITLE
Bugfix/vectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+out/build/
+.vs/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,63 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "windows-base",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "installDir": "${sourceDir}/out/install/${presetName}",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "cl.exe",
+                "CMAKE_CXX_COMPILER": "cl.exe",
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "x64-debug",
+            "displayName": "x64 Debug",
+            "inherits": "windows-base",
+            "architecture": {
+                "value": "x64",
+                "strategy": "external"
+            },
+          "cacheVariables": {
+            "CMAKE_BUILD_TYPE": "Debug",
+            "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+          }
+        },
+        {
+            "name": "x64-release",
+            "displayName": "x64 Release",
+            "inherits": "x64-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "x86-debug",
+            "displayName": "x86 Debug",
+            "inherits": "windows-base",
+            "architecture": {
+                "value": "x86",
+                "strategy": "external"
+            },
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "x86-release",
+            "displayName": "x86 Release",
+            "inherits": "x86-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        }
+    ]
+}

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,15 @@
+﻿{
+	"configurations": [
+		{
+			"name": "x64-Debug",
+			"generator": "Ninja",
+			"configurationType": "Debug",
+			"inheritEnvironments": [ "msvc_x64_x64" ],
+			"buildRoot": "${projectDir}\\out\\build\\${name}",
+			"installRoot": "${projectDir}\\out\\install\\${name}",
+			"cmakeCommandArgs": "",
+			"buildCommandArgs": "",
+			"ctestCommandArgs": "",
+		}
+	]
+}

--- a/CMakeUserPresets.json
+++ b/CMakeUserPresets.json
@@ -1,0 +1,12 @@
+{
+	"version": 3,
+	"configurePresets": [
+		{
+			"name": "default",
+			"inherits": "windows-base",
+			"environment": {
+				"VCPKG_ROOT": "h:\\src\\vcpkg"
+			}
+		}
+	]
+}

--- a/src/obj.cpp
+++ b/src/obj.cpp
@@ -37,9 +37,9 @@ float Obj::is_obj(const std::string& filename) {
 	size_t sample_size = file_handle.tellg();
 	file_handle.seekg(file_handle.beg);
 	sample_size = std::min(sample_size, size_t(1024)); //Limit to 1kB.
-	char sample_chars[sample_size];
-	file_handle.read(sample_chars, sample_size);
-	std::string sample(sample_chars); //We've read up to 1kB from this file now.
+	std::vector<char> buffer(sample_size);
+	file_handle.read(&buffer.front(), sample_size);
+	std::string sample(buffer.data(), buffer.size()); //We've read up to 1kB from this file now.
 
 	//Match a line with this complicated regex that captures almost every possible line in OBJ files.
 	const std::regex correct_line("^\\\\?$|((#|mtllib |usemtl |o |g |s |mg |cstype ).*|v[np]? [-+]?\\d*\\.?\\d+([eE][-+]?\\d+)? [-+]?\\d*\\.?\\d+([eE][-+]?\\d+)? [-+]?\\d*\\.?\\d+([eE][-+]?\\d+)?|vt [-+]?\\d*\\.?\\d+([eE][-+]?\\d+)? [-+]?\\d*\\.?\\d+([eE][-+]?\\d+)?|(f|p|l|curv|curv2|surf)( -?\\d+(\\/\\d*)?(\\/\\d+)?)+)\\\\?");
@@ -90,7 +90,7 @@ std::vector<std::string> Obj::preprocess(const std::string& filename) const {
 		}
 
 		//Process line continuation.
-		if(!lines.empty() && lines.back()[lines.back().length() - 1] == '\\') { //Previous line had a line continuation.
+		if(!lines.empty() && lines.back().length() > 0 && lines.back()[lines.back().length() - 1] == '\\') { //Previous line had a line continuation.
 			lines[lines.size() - 1][lines.back().length() - 1] = ' '; //Turn the backslash into a space.
 			lines[lines.size() - 1] += line; //Add the new line.
 		} else {

--- a/src/stl_ascii.cpp
+++ b/src/stl_ascii.cpp
@@ -34,9 +34,9 @@ float StlAscii::is_stl_ascii(const std::string& filename) {
 	size_t sample_size = file_handle.tellg();
 	file_handle.seekg(file_handle.beg);
 	sample_size = std::min(sample_size, size_t(1024)); //Limit to 1kB.
-	char sample_chars[sample_size];
-	file_handle.read(sample_chars, sample_size);
-	std::string sample(sample_chars); //We've read up to 1kB from this file now.
+	std::vector<char> buffer(sample_size);
+	file_handle.read(&buffer.front(), sample_size);
+	std::string sample(buffer.data(), buffer.size()); //We've read up to 1kB from this file now.
 
 	//Match a line with this regex that matches on the possible lines of ASCII STL.
 	const std::regex correct_line("^\\s*$|\\s*solid.*|\\s*facet\\s*|\\s*facet normal .*|\\s*outer loop\\s*|\\s*vertex .*|\\s*endloop\\s*|\\s*endfacet\\s*|\\s*endsolid.*");

--- a/src/stl_binary.cpp
+++ b/src/stl_binary.cpp
@@ -8,6 +8,7 @@
 
 #include <fstream> //To read binary STL files.
 #include <iostream> //To message progress.
+#include <array>
 
 #include "stl_binary.hpp" //The definitions for this file.
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "2ddc10c8afa00a762a69f21f6427849fe906ede0",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": [
+    "libzip"
+  ]
+}


### PR DESCRIPTION
Changing the char array using in obj.cpp + stl_ascii.cpp to use vector<char> instead. `char[sample_size]` would not build for me under visual studio.

Also fixing an issue in obj.cpp if the previous line was empty.

note: This pr is pulling in my other branch changes as well (adding support for visual studio + cmakesettings)